### PR TITLE
Check if config file exists before returning path

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use std::{env::VarError, fs};
+use std::{env::VarError, fs, path::Path};
 
 use serde::Deserialize;
 
@@ -71,7 +71,10 @@ impl Config {
             )),
             Err(VarError::NotPresent) => match dirs::config_local_dir() {
                 Some(dir) => match dir.join("clock-rs/conf.toml").to_str() {
-                    Some(path) => Ok(Some(path.to_string())),
+                    Some(path) => match Path::new(path).exists() {
+                        true => Ok(Some(path.to_string())),
+                        false => Ok(None),
+                    },
                     None => Err("configuration path is not valid unicode".into()),
                 },
                 None => Ok(None),


### PR DESCRIPTION
Hello!
I saw your project from [reddit](https://www.reddit.com/r/unixporn/comments/1edam5c/oc_clockrs_a_clock_for_your_terminal/) and wanted to try it out, however I noticed that if you try to run the project without having created a configuration file, the program just crashes because it can't find the file.

I added a check so the program will use the default config if the file can't be found, by returning `None` for the `file_path` variable.