### PR TITLE
Fix timer edit code and rejection of zero interval, additional status bar with keybinding hints.

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,14 +1,18 @@
 pub mod args;
 
 use {super::config::Config, args::Args};
+use crate::error::Error;
 
 impl Args {
-    pub fn overwrite(self, config: &mut Config) {
+    pub fn overwrite(self, config: &mut Config) -> Result<(), Error> {
         if let Some(color) = self.color {
             config.general.color = color;
         }
 
         if let Some(interval) = self.interval {
+            if interval == 0 {
+                return Err(Error::ZeroInterval);
+            }
             config.general.interval = interval;
         }
 
@@ -43,5 +47,7 @@ impl Args {
         if self.hide_seconds {
             config.date.hide_seconds = true;
         }
+
+        Ok(())
     }
 }

--- a/src/clock/counter.rs
+++ b/src/clock/counter.rs
@@ -76,7 +76,7 @@ impl Counter {
 
             if secs == 0 && kill {
                 State::exit();
-                process::exit(1);
+                process::exit(0);
             }
         }
 

--- a/src/clock/mod.rs
+++ b/src/clock/mod.rs
@@ -35,7 +35,7 @@ pub struct Clock {
 impl Clock {
     const WIDTH: u16 = 51;
     const WIDTH_NO_SECONDS: u16 = 32;
-    const HEIGHT: u16 = 7;
+    const HEIGHT: u16 = 9;
     const SUFFIX_LEN: u16 = 5;
     const AM_SUFFIX: &'static str = " [AM]";
     const PM_SUFFIX: &'static str = " [PM]";

--- a/src/color.rs
+++ b/src/color.rs
@@ -155,6 +155,50 @@ impl FromStr for Color {
     }
 }
 
+pub fn next_color(current: &Color) -> Color {
+    match current {
+        Color::Black => Color::Red,
+        Color::Red => Color::Green,
+        Color::Green => Color::Yellow,
+        Color::Yellow => Color::Blue,
+        Color::Blue => Color::Magenta,
+        Color::Magenta => Color::Cyan,
+        Color::Cyan => Color::White,
+        Color::White => Color::BrightBlack,
+        Color::BrightBlack => Color::BrightRed,
+        Color::BrightRed => Color::BrightGreen,
+        Color::BrightGreen => Color::BrightYellow,
+        Color::BrightYellow => Color::BrightBlue,
+        Color::BrightBlue => Color::BrightMagenta,
+        Color::BrightMagenta => Color::BrightCyan,
+        Color::BrightCyan => Color::BrightWhite,
+        Color::BrightWhite => Color::Black,
+        Color::Rgb { .. } => Color::White,
+    }
+}
+
+pub fn prev_color(current: &Color) -> Color {
+    match current {
+        Color::Black => Color::BrightWhite,
+        Color::Red => Color::Black,
+        Color::Green => Color::Red,
+        Color::Yellow => Color::Green,
+        Color::Blue => Color::Yellow,
+        Color::Magenta => Color::Blue,
+        Color::Cyan => Color::Magenta,
+        Color::White => Color::Cyan,
+        Color::BrightBlack => Color::White,
+        Color::BrightRed => Color::BrightBlack,
+        Color::BrightGreen => Color::BrightRed,
+        Color::BrightYellow => Color::BrightGreen,
+        Color::BrightBlue => Color::BrightYellow,
+        Color::BrightMagenta => Color::BrightBlue,
+        Color::BrightCyan => Color::BrightMagenta,
+        Color::BrightWhite => Color::BrightCyan,
+        Color::Rgb { .. } => Color::White,
+    }
+}
+
 impl<'de> Deserialize<'de> for Color {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,6 +22,8 @@ pub enum Error {
     ReadFile { path: String, err: String },
     #[error("failed to parse configuration file `{path}`:\n{err}")]
     ParseToml { path: String, err: String },
+    #[error("interval must be greater than 0")]
+    ZeroInterval,
     #[error("IO error: {0}")]
     Io(#[from] io::Error),
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -27,6 +27,7 @@ use crate::{
         time_zone::TimeZone,
         Clock,
     },
+    color::{next_color, prev_color},
     config::Config,
     error::Error,
 };
@@ -41,7 +42,7 @@ impl State {
         let mut config = Config::parse()?;
         let mode = args.mode.clone();
 
-        args.overwrite(&mut config);
+        args.overwrite(&mut config)?;
 
         let clock_mode = Self::clock_mode(mode, &config)?;
         let mut clock = Clock::new(config, clock_mode);
@@ -152,6 +153,59 @@ impl State {
                         let (width, height) = terminal::size()?;
                         self.refresh_display(width, height)?;
                     }
+                    // keybinds for all of the commands
+                    KeyEvent {
+                        code: KeyCode::Char('-'),
+                        kind: KeyEventKind::Press,
+                        modifiers: KeyModifiers::NONE,
+                        ..
+                    } => {
+                        let ms = self.clock.interval.as_millis() as u64;
+                        self.clock.interval = Duration::from_millis(ms.saturating_sub(100).max(100));
+                    }
+                    KeyEvent {
+                        code: KeyCode::Char('+' | '='),
+                        kind: KeyEventKind::Press,
+                        modifiers: KeyModifiers::NONE,
+                        ..
+                    } => {
+                        let ms = self.clock.interval.as_millis() as u64;
+                        self.clock.interval = Duration::from_millis((ms + 100).min(9900));
+                    }
+                    KeyEvent {
+                        code: KeyCode::Char('c'),
+                        kind: KeyEventKind::Press,
+                        modifiers: KeyModifiers::NONE,
+                        ..
+                    } => {
+                        self.clock.color = next_color(&self.clock.color);
+                    }
+                    KeyEvent {
+                        code: KeyCode::Char('C'),
+                        kind: KeyEventKind::Press,
+                        modifiers: KeyModifiers::SHIFT,
+                        ..
+                    } => {
+                        self.clock.color = prev_color(&self.clock.color);
+                    }
+                    KeyEvent {
+                        code: KeyCode::Char('b' | 'B'),
+                        kind: KeyEventKind::Press,
+                        modifiers: KeyModifiers::NONE | KeyModifiers::SHIFT,
+                        ..
+                    } => {
+                        self.clock.blink = !self.clock.blink;
+                    }
+                    KeyEvent {
+                        code: KeyCode::Char('s' | 'S'),
+                        kind: KeyEventKind::Press,
+                        modifiers: KeyModifiers::NONE | KeyModifiers::SHIFT,
+                        ..
+                    } => {
+                        self.clock.hide_seconds = !self.clock.hide_seconds;
+                        let (width, height) = terminal::size()?;
+                        self.refresh_display(width, height)?;
+                    }
                     _ => (),
                 },
                 Event::Resize(width, height) => self.refresh_display(width, height)?,
@@ -217,7 +271,34 @@ impl State {
         let mut buffered_writer = BufWriter::new(lock);
 
         self.clock.fmt(&mut buffered_writer)?;
+
+        // pin the status bar
+        self.render_statusbar(&mut buffered_writer, width, height)?;
+
         buffered_writer.flush()?;
+
+        Ok(())
+    }
+
+    fn render_statusbar(&self, w: &mut BufWriter<io::StdoutLock<'_>>, width: u16, height: u16) -> Result<(), Error> {
+        let ms = self.clock.interval.as_millis();
+        let right = format!(" {}ms \u{2014}", ms); // " 200ms —"
+        let left = "\u{2014} b: Blink | s: Secs | c: Color | -/+: Interval "; // "— b: ..."
+
+        let left_len = left.chars().count();
+        let right_len = right.chars().count();
+        let total = width as usize;
+
+        // fill dashes between left and right and clamp we never go negative
+        let fill_count = total.saturating_sub(left_len + right_len);
+        let fill = "\u{2014}".repeat(fill_count);
+
+        // move to the bottom row and write everything
+        write!(
+            w,
+            "\x1B[{};1H\x1B[2m{left}{fill}{right}\x1B[0m",
+            height,
+        )?;
 
         Ok(())
     }


### PR DESCRIPTION
Adds a persistent status bar pinned to the bottom of the terminal, inspired by mactop. Shows keybinding hints on the left and the polling interval on the right. Also fixes the timer exit code (it was 1, should be 0) and rejects --interval 0 with a proper error.