### PR TITLE
Add configurable millisecond time formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,9 @@ Here is a list of the available fields inside the `conf.toml` file.
 | `date.fmt`                | Specify the date format                    | A [chrono format](https://docs.rs/chrono/latest/chrono/format/strftime/index.html) string, e.g. `"%A, %B %d, %Y"`.  | `"%d-%m-%Y"` |
 | `date.use_12h`            | Use the 12h format                         | `true` or `false`.                 | `false`      |
 | `date.utc`                | Use UTC time                               | `true` or `false`.                 | `false`      |
-| `date.hide_seconds`       | Do not show seconds                        | `true` or `false`.                 | `false`      |
+| `date.hide_seconds`       | Do not show seconds. This is ignored when the active time format includes milliseconds. | `true` or `false`. | `false` |
+| `clock.fmt`               | Specify the clock format                   | `"hh:mm:ss"` or `"hh:mm:ss.SSS"`.  | `"hh:mm:ss"` |
+| `counter.fmt`             | Specify the timer and stopwatch format     | `"hh:mm:ss"` or `"hh:mm:ss.SSS"`.  | `"hh:mm:ss"` |
 
 ### Example
 
@@ -265,6 +267,12 @@ fmt = "%A, %B %d, %Y"
 use_12h = true
 utc = true
 hide_seconds = true
+
+[clock]
+fmt = "hh:mm:ss.SSS"
+
+[counter]
+fmt = "hh:mm:ss.SSS"
 ```
 
 The default configuration can be found [here](public/default.toml).

--- a/public/default.toml
+++ b/public/default.toml
@@ -16,3 +16,9 @@ fmt = "%d-%m-%Y"
 use_12h = false
 utc = false
 hide_seconds = false
+
+[clock]
+fmt = "hh:mm:ss"
+
+[counter]
+fmt = "hh:mm:ss"

--- a/src/character.rs
+++ b/src/character.rs
@@ -6,11 +6,13 @@ use crate::{
 pub enum Character {
     Num(u32),
     Colon,
+    Dot,
     Empty,
 }
 
 impl Character {
     const COLON: [Segment; 5] = [Empty, Center, Empty, Center, Empty];
+    const DOT: [Segment; 5] = [Empty, Empty, Empty, Empty, Center];
     const NUMBERS: [Segment; 50] = [
         Full, Sides, Sides, Sides, Full, // 0
         Right, Right, Right, Right, Right, // 1
@@ -28,6 +30,7 @@ impl Character {
         match self {
             Self::Num(n) => &Self::NUMBERS[*n as usize * 5 + row],
             Self::Colon => &Self::COLON[row],
+            Self::Dot => &Self::DOT[row],
             Self::Empty => &Empty,
         }
         .fmt(color)

--- a/src/clock/counter.rs
+++ b/src/clock/counter.rs
@@ -3,7 +3,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::state::State;
+use crate::{clock::TimeParts, state::State};
 
 pub struct Counter {
     pub text: &'static str,
@@ -58,32 +58,109 @@ impl Counter {
         }
     }
 
-    pub fn get_time(&self) -> (u32, u32, u32) {
-        let mut elapsed = if self.paused {
+    pub fn exit_if_finished(&self) {
+        if self.should_exit() {
+            State::exit();
+            process::exit(0);
+        }
+    }
+
+    fn elapsed(&self) -> Duration {
+        if self.paused {
             match self.last_pause {
                 Some(last_pause) => last_pause.duration_since(self.start),
                 _ => Duration::from_secs(0),
             }
         } else {
             self.start.elapsed()
-        };
+        }
+    }
 
+    fn should_exit(&self) -> bool {
+        let elapsed = self.elapsed();
+
+        matches!(
+            self.ty,
+            CounterType::Timer {
+                duration,
+                kill: true
+            } if elapsed >= duration
+        )
+    }
+
+    pub fn get_time(&self, show_milliseconds: bool) -> TimeParts {
+        let mut elapsed = self.elapsed();
         let mut secs = elapsed.as_secs() as u32;
 
-        if let CounterType::Timer { duration, kill } = self.ty {
-            elapsed = duration.saturating_sub(elapsed.saturating_sub(Duration::from_secs(1)));
+        if let CounterType::Timer { duration, .. } = self.ty {
+            elapsed = if show_milliseconds {
+                duration.saturating_sub(elapsed)
+            } else {
+                duration.saturating_sub(elapsed.saturating_sub(Duration::from_secs(1)))
+            };
             secs = elapsed.as_secs() as u32;
-
-            if secs == 0 && kill {
-                State::exit();
-                process::exit(0);
-            }
         }
 
         let hours = secs / 3600;
         let minutes = (secs % 3600) / 60;
         let seconds = secs % 60;
 
-        (hours, minutes, seconds)
+        TimeParts {
+            hour: hours,
+            minute: minutes,
+            second: seconds,
+            millisecond: elapsed.subsec_millis(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, Instant};
+
+    use super::{Counter, CounterType};
+
+    fn paused_timer(duration: Duration, elapsed: Duration, kill: bool) -> Counter {
+        let start = Instant::now();
+
+        Counter {
+            text: Counter::TEXT_PAUSED,
+            ty: CounterType::Timer { duration, kill },
+            start,
+            last_pause: Some(start + elapsed),
+            paused: true,
+        }
+    }
+
+    #[test]
+    fn timer_whole_seconds_keeps_previous_countdown_rounding() {
+        let counter = paused_timer(Duration::from_secs(5), Duration::from_millis(4200), false);
+        let time = counter.get_time(false);
+
+        assert_eq!(time.second, 1);
+        assert_eq!(time.millisecond, 800);
+    }
+
+    #[test]
+    fn timer_milliseconds_use_exact_remaining_time() {
+        let counter = paused_timer(Duration::from_secs(5), Duration::from_millis(4200), false);
+        let time = counter.get_time(true);
+
+        assert_eq!(time.second, 0);
+        assert_eq!(time.millisecond, 800);
+    }
+
+    #[test]
+    fn timer_kill_uses_elapsed_deadline() {
+        let counter = paused_timer(Duration::from_secs(5), Duration::from_secs(5), true);
+
+        assert!(counter.should_exit());
+    }
+
+    #[test]
+    fn paused_timer_before_deadline_does_not_exit() {
+        let counter = paused_timer(Duration::from_secs(5), Duration::from_secs(4), true);
+
+        assert!(!counter.should_exit());
     }
 }

--- a/src/clock/mod.rs
+++ b/src/clock/mod.rs
@@ -8,7 +8,11 @@ use std::{
 };
 
 use crate::{
-    character::Character, clock::mode::ClockMode, color::Color, config::Config, error::Error,
+    character::Character,
+    clock::mode::ClockMode,
+    color::Color,
+    config::{Config, TimeFormat},
+    error::Error,
     position::Position,
 };
 
@@ -17,6 +21,13 @@ pub struct Padding {
     pub top: u16,
     clock: String,
     text: String,
+}
+
+pub struct TimeParts {
+    pub hour: u32,
+    pub minute: u32,
+    pub second: u32,
+    pub millisecond: u32,
 }
 
 pub struct Clock {
@@ -28,13 +39,18 @@ pub struct Clock {
     pub color: Color,
     pub use_12h: bool,
     pub hide_seconds: bool,
+    pub clock_format: TimeFormat,
+    pub counter_format: TimeFormat,
     pub blink: bool,
     pub bold: bool,
 }
 
 impl Clock {
-    const WIDTH: u16 = 51;
-    const WIDTH_NO_SECONDS: u16 = 32;
+    const DIGIT_WIDTH: u16 = 7;
+    const SEPARATOR_WIDTH: u16 = 5;
+    const WIDTH: u16 = Self::DIGIT_WIDTH * 6 + Self::SEPARATOR_WIDTH * 2 - 1;
+    const WIDTH_NO_SECONDS: u16 = Self::DIGIT_WIDTH * 4 + Self::SEPARATOR_WIDTH - 1;
+    const WIDTH_MILLISECONDS: u16 = Self::DIGIT_WIDTH * 9 + Self::SEPARATOR_WIDTH * 3 - 1;
     const HEIGHT: u16 = 7;
     const SUFFIX_LEN: u16 = 5;
     const AM_SUFFIX: &'static str = " [AM]";
@@ -50,6 +66,8 @@ impl Clock {
             color: config.general.color,
             use_12h: config.date.use_12h,
             hide_seconds: config.date.hide_seconds,
+            clock_format: config.clock.fmt,
+            counter_format: config.counter.fmt,
             blink: config.general.blink,
             bold: config.general.bold,
         }
@@ -58,7 +76,11 @@ impl Clock {
     pub fn update_padding(&mut self, width: u16, height: u16) -> Result<(), Error> {
         let clock_width = self.width();
         let text_len = self.mode.text(clock_width)?.len() as u16
-            + if self.use_12h { Self::SUFFIX_LEN } else { 0 };
+            + if self.shows_12h_suffix() {
+                Self::SUFFIX_LEN
+            } else {
+                0
+            };
 
         let half_width = clock_width / 2;
 
@@ -80,19 +102,35 @@ impl Clock {
     }
 
     fn width(&self) -> u16 {
-        if self.hide_seconds {
-            return Self::WIDTH_NO_SECONDS;
+        match self.time_format() {
+            format if format.shows_milliseconds() => Self::WIDTH_MILLISECONDS,
+            _ if self.hide_seconds => Self::WIDTH_NO_SECONDS,
+            _ => Self::WIDTH,
         }
+    }
 
-        Self::WIDTH
+    fn time_format(&self) -> TimeFormat {
+        match &self.mode {
+            ClockMode::Counter(_) => self.counter_format,
+            ClockMode::Time { .. } => self.clock_format,
+        }
+    }
+
+    fn shows_12h_suffix(&self) -> bool {
+        matches!(&self.mode, ClockMode::Time { .. }) && self.use_12h
+    }
+
+    fn shows_seconds(&self, time_format: TimeFormat) -> bool {
+        !self.hide_seconds || time_format.shows_milliseconds()
     }
 
     pub fn fmt(&self, w: &mut BufWriter<StdoutLock<'_>>) -> Result<(), Error> {
+        let time_format = self.time_format();
         let mut text = self.mode.text(self.width())?;
-        let (mut hour, minute, second) = self.mode.get_time();
+        let mut time = self.mode.get_time(time_format.shows_milliseconds());
 
-        if matches!(self.mode, ClockMode::Time { .. }) && self.use_12h {
-            let suffix = if hour < 12 {
+        if self.shows_12h_suffix() {
+            let suffix = if time.hour < 12 {
                 Self::AM_SUFFIX
             } else {
                 Self::PM_SUFFIX
@@ -100,35 +138,44 @@ impl Clock {
 
             text.push_str(suffix);
 
-            if hour > 12 {
-                hour -= 12;
-            } else if hour == 0 {
-                hour = 12;
+            if time.hour > 12 {
+                time.hour -= 12;
+            } else if time.hour == 0 {
+                time.hour = 12;
             }
         }
 
         let color = &self.color;
 
         for row in 0..5 {
-            let colon_character = if self.blink && (second & 1 == 1) {
+            let colon_character = if self.blink && (time.second & 1 == 1) {
                 Character::Empty
             } else {
                 Character::Colon
             };
 
             let colon = colon_character.fmt(color, row);
-            let h0 = Character::Num(hour / 10).fmt(color, row);
-            let h1 = Character::Num(hour % 10).fmt(color, row);
-            let m0 = Character::Num(minute / 10).fmt(color, row);
-            let m1 = Character::Num(minute % 10).fmt(color, row);
+            let h0 = Character::Num(time.hour / 10).fmt(color, row);
+            let h1 = Character::Num(time.hour % 10).fmt(color, row);
+            let m0 = Character::Num(time.minute / 10).fmt(color, row);
+            let m1 = Character::Num(time.minute % 10).fmt(color, row);
 
             write!(w, "{}{h0}{h1}{colon}{m0}{m1}", self.padding.clock)?;
 
-            if !self.hide_seconds {
-                let s0 = Character::Num(second / 10).fmt(color, row);
-                let s1 = Character::Num(second % 10).fmt(color, row);
+            if self.shows_seconds(time_format) {
+                let s0 = Character::Num(time.second / 10).fmt(color, row);
+                let s1 = Character::Num(time.second % 10).fmt(color, row);
 
                 write!(w, "{colon}{s0}{s1}")?;
+            }
+
+            if time_format.shows_milliseconds() {
+                let dot = Character::Dot.fmt(color, row);
+                let ms0 = Character::Num(time.millisecond / 100).fmt(color, row);
+                let ms1 = Character::Num(time.millisecond / 10 % 10).fmt(color, row);
+                let ms2 = Character::Num(time.millisecond % 10).fmt(color, row);
+
+                write!(w, "{dot}{ms0}{ms1}{ms2}")?;
             }
 
             writeln!(w, "\r")?;
@@ -144,5 +191,59 @@ impl Clock {
         )?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        clock::{
+            counter::{Counter, CounterType},
+            mode::ClockMode,
+        },
+        config::{Config, TimeFormat},
+    };
+
+    use super::Clock;
+
+    #[test]
+    fn whole_second_counter_respects_hide_seconds() {
+        let mut config = Config::default();
+        config.date.hide_seconds = true;
+
+        let clock = Clock::new(
+            config,
+            ClockMode::Counter(Counter::new(CounterType::Stopwatch)),
+        );
+
+        assert_eq!(clock.width(), Clock::WIDTH_NO_SECONDS);
+        assert!(!clock.shows_seconds(clock.time_format()));
+    }
+
+    #[test]
+    fn millisecond_counter_shows_seconds_when_hide_seconds_is_set() {
+        let mut config = Config::default();
+        config.date.hide_seconds = true;
+        config.counter.fmt = TimeFormat::HoursMinutesSecondsMilliseconds;
+
+        let clock = Clock::new(
+            config,
+            ClockMode::Counter(Counter::new(CounterType::Stopwatch)),
+        );
+
+        assert_eq!(clock.width(), Clock::WIDTH_MILLISECONDS);
+        assert!(clock.shows_seconds(clock.time_format()));
+    }
+
+    #[test]
+    fn millisecond_wall_clock_shows_seconds_when_hide_seconds_is_set() {
+        let mut config = Config::default();
+        config.date.hide_seconds = true;
+        config.clock.fmt = TimeFormat::HoursMinutesSecondsMilliseconds;
+
+        let clock = Clock::new(config, ClockMode::default());
+
+        assert_eq!(clock.width(), Clock::WIDTH_MILLISECONDS);
+        assert!(clock.shows_seconds(clock.time_format()));
     }
 }

--- a/src/clock/mode.rs
+++ b/src/clock/mode.rs
@@ -1,5 +1,5 @@
 use crate::{
-    clock::{counter::Counter, time_zone::TimeZone},
+    clock::{counter::Counter, time_zone::TimeZone, TimeParts},
     error::Error,
 };
 
@@ -12,9 +12,9 @@ pub enum ClockMode {
 }
 
 impl ClockMode {
-    pub fn get_time(&self) -> (u32, u32, u32) {
+    pub fn get_time(&self, show_counter_milliseconds: bool) -> TimeParts {
         match self {
-            Self::Counter(counter) => counter.get_time(),
+            Self::Counter(counter) => counter.get_time(show_counter_milliseconds),
             Self::Time { time_zone, .. } => time_zone.get_time(),
         }
     }

--- a/src/clock/time_zone.rs
+++ b/src/clock/time_zone.rs
@@ -2,7 +2,7 @@ use std::fmt::Write;
 
 use chrono::{Local, Timelike, Utc};
 
-use crate::error::Error;
+use crate::{clock::TimeParts, error::Error};
 
 pub enum TimeZone {
     Local,
@@ -18,16 +18,26 @@ impl TimeZone {
         Self::Local
     }
 
-    pub fn get_time(&self) -> (u32, u32, u32) {
+    pub fn get_time(&self) -> TimeParts {
         if let Self::Utc = self {
             let utc = Utc::now();
 
-            return (utc.hour(), utc.minute(), utc.second());
+            return TimeParts {
+                hour: utc.hour(),
+                minute: utc.minute(),
+                second: utc.second(),
+                millisecond: utc.nanosecond() / 1_000_000,
+            };
         }
 
         let local = Local::now();
 
-        (local.hour(), local.minute(), local.second())
+        TimeParts {
+            hour: local.hour(),
+            minute: local.minute(),
+            second: local.second(),
+            millisecond: local.nanosecond() / 1_000_000,
+        }
     }
 
     pub fn text(&self, date_format: &str, max_len: u16) -> Result<String, Error> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,8 @@ pub struct Config {
     pub general: GeneralConfig,
     pub position: PositionConfig,
     pub date: DateConfig,
+    pub clock: ClockConfig,
+    pub counter: CounterConfig,
 }
 
 #[derive(Deserialize)]
@@ -65,6 +67,56 @@ impl Default for DateConfig {
     }
 }
 
+pub type ClockConfig = TimeFormatConfig;
+pub type CounterConfig = TimeFormatConfig;
+
+#[derive(Default, Deserialize)]
+#[serde(default)]
+pub struct TimeFormatConfig {
+    pub fmt: TimeFormat,
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq)]
+#[serde(try_from = "String")]
+pub enum TimeFormat {
+    #[default]
+    HoursMinutesSeconds,
+    HoursMinutesSecondsMilliseconds,
+}
+
+impl TimeFormat {
+    pub const HOURS_MINUTES_SECONDS: &'static str = "hh:mm:ss";
+    pub const HOURS_MINUTES_SECONDS_MILLISECONDS: &'static str = "hh:mm:ss.SSS";
+
+    pub fn shows_milliseconds(self) -> bool {
+        matches!(self, Self::HoursMinutesSecondsMilliseconds)
+    }
+}
+
+impl TryFrom<String> for TimeFormat {
+    type Error = String;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::try_from(value.as_str())
+    }
+}
+
+impl TryFrom<&str> for TimeFormat {
+    type Error = String;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            Self::HOURS_MINUTES_SECONDS => Ok(Self::HoursMinutesSeconds),
+            Self::HOURS_MINUTES_SECONDS_MILLISECONDS => Ok(Self::HoursMinutesSecondsMilliseconds),
+            _ => Err(format!(
+                "expected `{}` or `{}`",
+                Self::HOURS_MINUTES_SECONDS,
+                Self::HOURS_MINUTES_SECONDS_MILLISECONDS
+            )),
+        }
+    }
+}
+
 impl Config {
     pub fn parse() -> Result<Self, Error> {
         let path = match env::var("CONF_PATH") {
@@ -104,5 +156,65 @@ impl Config {
             path: file_path,
             err: err.to_string(),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Config, TimeFormat};
+
+    #[test]
+    fn time_formats_default_to_whole_seconds() {
+        let config: Config = toml::from_str("").unwrap();
+
+        assert_eq!(config.clock.fmt, TimeFormat::HoursMinutesSeconds);
+        assert_eq!(config.counter.fmt, TimeFormat::HoursMinutesSeconds);
+    }
+
+    #[test]
+    fn clock_format_supports_milliseconds() {
+        let config: Config = toml::from_str(
+            r#"
+            [clock]
+            fmt = "hh:mm:ss.SSS"
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            config.clock.fmt,
+            TimeFormat::HoursMinutesSecondsMilliseconds
+        );
+    }
+
+    #[test]
+    fn counter_format_supports_milliseconds() {
+        let config: Config = toml::from_str(
+            r#"
+            [counter]
+            fmt = "hh:mm:ss.SSS"
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            config.counter.fmt,
+            TimeFormat::HoursMinutesSecondsMilliseconds
+        );
+    }
+
+    #[test]
+    fn counter_format_rejects_unknown_format() {
+        let err = match toml::from_str::<Config>(
+            r#"
+            [counter]
+            fmt = "HH:MM:SS.SSS"
+            "#,
+        ) {
+            Ok(_) => panic!("invalid counter format was accepted"),
+            Err(err) => err,
+        };
+
+        assert!(err.to_string().contains("expected `hh:mm:ss`"));
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -110,6 +110,7 @@ impl State {
                 self.reload_config()?;
             }
 
+            self.exit_if_finished();
             self.render()?;
 
             if !event::poll(self.clock.interval)? {
@@ -187,6 +188,8 @@ impl State {
 
         clock.use_12h = config.date.use_12h;
         clock.hide_seconds = config.date.hide_seconds;
+        clock.clock_format = config.clock.fmt;
+        clock.counter_format = config.counter.fmt;
 
         if let ClockMode::Time {
             time_zone,
@@ -199,6 +202,12 @@ impl State {
 
         let (width, height) = terminal::size()?;
         self.refresh_display(width, height)
+    }
+
+    fn exit_if_finished(&self) {
+        if let ClockMode::Counter(counter) = &self.clock.mode {
+            counter.exit_if_finished();
+        }
     }
 
     fn render(&self) -> Result<(), Error> {


### PR DESCRIPTION
Adds optional millisecond precision for the main clock, timer, and stopwatch displays.
Defaults remain unchanged. Users can opt in with:
```toml
[clock]
fmt = "hh:mm:ss.SSS"

[counter]
fmt = "hh:mm:ss.SSS"
```